### PR TITLE
Art. 5a ust. 1 pkt 1: Podwyższenie stawki bazowej do 0,1%/0,2%

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -28,7 +28,9 @@ W ustawie z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z
    „**Art. 5a.**
 
    1. Stawka podatku od budynku mieszkalnego jednorodzinnego i lokalu mieszkalnego wynosi:
-      1. 0,02% wartości dla budynku mieszkalnego jednorodzinnego i lokalu mieszkalnego, który jest pierwszym albo drugim budynkiem mieszkalnym jednorodzinnym lub lokalem mieszkalnym nabytym przez podatnika;
+      1. w przypadku budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego stanowiącego pierwszy lub drugi budynek mieszkalny jednorodzinny lub lokal mieszkalny nabyty przez podatnika:
+         1. 0,1% wartości dla pierwszego budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego nabytego przez podatnika;
+         2. 0,2% wartości dla drugiego budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego nabytego przez podatnika;
       2. w przypadku budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego stanowiącego trzeci albo kolejny budynek mieszkalny jednorodzinny lub lokal mieszkalny nabyty przez podatnika:
          1. 0,5% wartości w pierwszym roku od dnia wejścia w życie przepisów wprowadzających podatek od wartości nieruchomości,
          2. w każdym kolejnym roku stawka podatku ulega zwiększeniu o 0,1 punktu procentowego do maksymalnie 1,5% wartości.


### PR DESCRIPTION
## Zmiana

Rozbicie stawki bazowej (art. 5a ust. 1 pkt 1) na dwie odrębne:
- **0,1%** wartości dla pierwszej nieruchomości
- **0,2%** wartości dla drugiej nieruchomości

Zastępuje obecną symboliczną stawkę 0,02% dla obu.

## Uzasadnienie

Obecna stawka 0,02% jest ekonomicznie bezznaczeniowa — przy mieszkaniu o wartości 500 tys. PLN to ok. **100 PLN/rok**. Nie stanowi żadnej zachęty behawioralnej ani realnego źródła dochodów gminy.

Proponowane stawki:
| Nieruchomość | Stawka | Podatek (500 tys. PLN) | Podatek (miesięcznie) |
|---|---|---|---|
| 1. (obecna) | 0,02% | 100 PLN/rok | 8 PLN |
| 1. (nowa) | 0,1% | 500 PLN/rok | 42 PLN |
| 2. (obecna) | 0,02% | 100 PLN/rok | 8 PLN |
| 2. (nowa) | 0,2% | 1000 PLN/rok | 83 PLN |

Dla porównania — średnie stawki podatku od nieruchomości w krajach UE to **0,3–1%** wartości. Proponowane 0,1% pozostaje jedną z najniższych w Europie.

## Kontekst

Obecnie obowiązujący podatek od nieruchomości mieszkalnych w Polsce to 1,25 PLN/m² (2026), co dla mieszkania 65 m² daje ~81 PLN/rok. Przejście na model ad valorem z 0,1% to zmiana rzędu ~8x, ale w wartościach bezwzględnych nadal bardzo przystępna kwota.