### PR TITLE
Art. 5a ust. 1 pkt 2-3: Przyspieszenie wdrożenia (3 lata) + eskalacja per nieruchomość

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -29,9 +29,14 @@ W ustawie z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z
 
    1. Stawka podatku od budynku mieszkalnego jednorodzinnego i lokalu mieszkalnego wynosi:
       1. 0,02% wartości dla budynku mieszkalnego jednorodzinnego i lokalu mieszkalnego, który jest pierwszym albo drugim budynkiem mieszkalnym jednorodzinnym lub lokalem mieszkalnym nabytym przez podatnika;
-      2. w przypadku budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego stanowiącego trzeci albo kolejny budynek mieszkalny jednorodzinny lub lokal mieszkalny nabyty przez podatnika:
-         1. 0,5% wartości w pierwszym roku od dnia wejścia w życie przepisów wprowadzających podatek od wartości nieruchomości,
-         2. w każdym kolejnym roku stawka podatku ulega zwiększeniu o 0,1 punktu procentowego do maksymalnie 1,5% wartości.
+      2. w przypadku budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego stanowiącego trzeci albo kolejny budynek mieszkalny jednorodzinny lub lokal mieszkalny nabyty przez podatnika, stawka bazowa wynosi:
+         1. 0,5% wartości w pierwszym roku podatkowym od dnia wejścia w życie niniejszej ustawy,
+         2. 1,0% wartości w drugim roku podatkowym od dnia wejścia w życie niniejszej ustawy,
+         3. 1,5% wartości w trzecim i każdym kolejnym roku podatkowym od dnia wejścia w życie niniejszej ustawy.
+      3. Stawkę bazową, o której mowa w pkt 2, podwyższa się w zależności od łącznej liczby budynków mieszkalnych jednorodzinnych i lokali mieszkalnych będących własnością podatnika, o:
+         1. 0,25 punktu procentowego wartości -- dla czwartego budynku lub lokalu,
+         2. 0,5 punktu procentowego wartości -- dla piątego budynku lub lokalu,
+         3. 1,0 punktu procentowego wartości -- dla szóstego i każdego kolejnego budynku lub lokalu.
    2. Przy ustalaniu stawki podatku, o której mowa w ust. 1, bierze się pod uwagę wszystkie budynki mieszkalne jednorodzinne i lokale mieszkalne na terenie Rzeczypospolitej Polskiej, których właścicielem lub współwłaścicielem jest podatnik.
    3. Stawkę, o której mowa w art. 5a ust. 1 pkt 2 oblicza się od trzeciego i kolejnego przedmiotu opodatkowania liczonego zgodnie z kolejnością ustaloną według dnia nabycia.
    4. W przypadku gdy podatnik, będący właścicielem co najmniej jednego budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego, nabywa w tym samym dniu więcej niż jeden taki budynek lub lokal, dla ustalenia stawki podatku określonej w ust. 1 pkt 1 za pierwszy przyjmuje się budynek mieszkalny jednorodzinny lub lokal mieszkalny o najniższej wartości.


### PR DESCRIPTION
## Zmiana

Dwie modyfikacje art. 5a ust. 1:

**1. Przyspieszenie harmonogramu (pkt 2):**
Obecny zapis: +0,1pp rocznie, osiągnięcie max 1,5% dopiero w **2037 r.** (10 lat).
Proponowany:
| Rok | Obecna stawka | Proponowana |
|-----|---------------|-------------|
| 2027 | 0,5% | 0,5% |
| 2028 | 0,6% | 1,0% |
| 2029+ | 0,7% | **1,5%** |
| 2037 | 1,5% | 1,5% |

**2. Eskalacja per nieruchomość (nowy pkt 3):**
Dopłata rosnąca z liczbą posiadanych nieruchomości, naliczana *ponad* stawkę bazową z pkt 2:

| Nieruchomość | Dopłata | Stawka łączna (od 2029) |
|---|---|---|
| 3. | — | 1,5% |
| 4. | +0,25pp | 1,75% |
| 5. | +0,5pp | 2,0% |
| 6.+ | +1,0pp | **2,5%** |

## Uzasadnienie

**Harmonogram:** 10-letni okres przejściowy to prezent dla spekulantów — daje dekadę na restrukturyzację portfeli i obejście ustawy. 3 lata to wystarczający czas na dostosowanie się, a pełna stawka 1,5% zostaje osiągnięta w 2029 r. zamiast dopiero w 2037 r. Przy obecnym harmonogramie stawka w roku wyborczym 2027 to zaledwie 0,7% — ustawa nie zdąży nawet pokazać swojej skuteczności przed oceną wyborców.

**Eskalacja:** Wzorowana na modelu singapurskim (Additional Buyer's Stamp Duty), gdzie stawki rosną wykładniczo z każdą kolejną nieruchomością. Flat rate 1,5% niezależnie od tego czy ktoś ma 3 czy 30 mieszkań nie tworzy wystarczającej presji na dużych inwestorów. Eskalacja celuje precyzyjnie w hurtowe skupowanie mieszkań.

Dla porównania — Singapur nakłada 30% na 3. nieruchomość obywatela i 65% na zakupy przez podmioty prawne.