### PR TITLE
Art. 5a ust. 8: Dopłata dla osób prawnych (+0,5pp) i nierezydentów (+1,0pp)

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -43,6 +43,9 @@ W ustawie z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z
       3. budynki mieszkalne jednorodzinne i lokale mieszkalne znajdujące się w budynkach, w których są obiekty budowlane uznane za budowle ochronne na podstawie przepisów ustawy z dnia 5 grudnia 2024 r. o ochronie ludności i obronie cywilnej (Dz. U. z 2024 r. poz. 1907 oraz z 2025 r. poz. 1705);
       4. budynki mieszkalne jednorodzinne, w których wartość wskaźnika rocznego zapotrzebowania na nieodnawialną energię pierwotną EP [kWh/(m²·rok)], obliczona według przepisów wydanych na podstawie art. 15 ustawy z dnia 29 sierpnia 2014 r. o charakterystyce energetycznej budynków (Dz. U. z 2024 r. poz. 101) wynosi 70 lub mniej;
       5. lokale mieszkalne znajdujące się w budynkach mieszkalnych wielorodzinnych, w których wartość wskaźnika rocznego zapotrzebowania na nieodnawialną energię pierwotną EP [kWh/(m²·rok)], obliczona według przepisów wydanych na podstawie art. 15 ustawy z dnia 29 sierpnia 2014 r. o charakterystyce energetycznej budynków wynosi 65 lub mniej.
+   8. Stawkę podatku ustaloną zgodnie z ust. 1 powiększa się o:
+      1. 0,5 punktu procentowego wartości -- w przypadku gdy podatnikiem jest osoba prawna lub jednostka organizacyjna niemająca osobowości prawnej, z wyłączeniem podmiotów, o których mowa w ust. 7 pkt 1 i 2;
+      2. 1,0 punkt procentowy wartości -- w przypadku gdy podatnikiem jest osoba fizyczna niemająca miejsca zamieszkania na terytorium Rzeczypospolitej Polskiej, osoba prawna niemająca siedziby na terytorium Rzeczypospolitej Polskiej, lub podmiot kontrolowany bezpośrednio lub pośrednio przez takie osoby.
 
    **Art. 5b.** Rada gminy może, w drodze uchwały, zmniejszyć lub zwiększyć podstawę opodatkowania budynków mieszkalnych jednorodzinnych lub lokali mieszkalnych na terenie gminy lub jej części, poprzez ustalenie współczynników korygujących w zakresie od 0,2 do 2 podstawy opodatkowania, w tym ze względu na:
 


### PR DESCRIPTION
## Zmiana

Dodanie nowego ust. 8 w art. 5a -- dopłata do stawki podatku naliczana *ponad* stawkę z ust. 1:

| Typ podatnika | Dopłata |
|---|---|
| Osoba prawna / jednostka organizacyjna | +0,5pp |
| Nierezydent (osoba fizyczna bez zamieszkania w RP, osoba prawna bez siedziby w RP, lub podmiot przez nich kontrolowany) | +1,0pp |

Z wyłączeniem podmiotów z ust. 7 pkt 1 i 2 (TBS, SIM, spółdzielnie mieszkaniowe, społeczne agencje najmu, państwowe osoby prawne).

## Przykłady

Osoba fizyczna-rezydent z 3 mieszkaniami (2029+): **1,5%** (bez dopłaty)
Spółka z o.o. z 3 mieszkaniami: 1,5% + 0,5pp = **2,0%**
Fundusz zagraniczny z 3 mieszkaniami: 1,5% + 1,0pp = **2,5%**

## Uzasadnienie

Obecna ustawa traktuje osoby prawne i zagranicznych inwestorów identycznie jak osoby fizyczne. Tymczasem to właśnie podmioty korporacyjne i zagraniczny kapitał (fundusze PRS, REIT-y) mają największą zdolność do hurtowego skupowania mieszkań, wypierając indywidualnych nabywców z rynku.

## Porównanie międzynarodowe

Proponowane dopłaty (+0,5pp / +1,0pp) są **wielokrotnie łagodniejsze** niż rozwiązania stosowane w innych krajach:

| Kraj | Mechanizm | Stawka |
|---|---|---|
| **Singapur** | Additional Buyer's Stamp Duty | **65%** podmioty prawne, **60%** cudzoziemcy |
| **Wielka Brytania** | Stamp Duty Land Tax surcharge | **+2%** nierezydenci, **+3%** podmioty prawne |
| **Kanada (BC/Ontario)** | Foreign Buyer Tax | **+20%** + zakaz zakupu dla cudzoziemców (2023-2027) |
| **Australia (NSW/VIC)** | Foreign Buyer Surcharge | **+8%** + zakaz zakupu istniejących nieruchomości (2025-2027) |
| **Francja** | Surtaxe résidence secondaire | **+5% do +60%** w zależności od gminy |
| **Nowa Zelandia** | Zakaz własności | Prawie całkowity **zakaz** zakupu przez cudzoziemców |
| **Polska (propozycja)** | Dopłata roczna | **+0,5pp** podmioty prawne, **+1,0pp** nierezydenci |

Kanada i Australia poszły dalej niż dopłaty -- wprowadziły **całkowity zakaz** zakupu nieruchomości mieszkalnych przez cudzoziemców. Nowa Zelandia utrzymuje taki zakaz permanentnie. Nasza propozycja jest daleka od tak radykalnych rozwiązań.

## Zgodność z prawem UE

Kryterium jest **rezydencja podatkowa** (miejsce zamieszkania/siedziba na terytorium RP), nie obywatelstwo, co zapewnia zgodność z art. 63 TFUE (swoboda przepływu kapitału). Podobne rozwiązania oparte na rezydencji (np. brytyjski SDLT surcharge) funkcjonują w ramach prawa europejskiego. TSUE akceptuje ograniczenia uzasadnione nadrzędnym interesem publicznym w polityce mieszkaniowej.