### PR TITLE
Usunięcie Art. 8 (zbędny okres przejściowy blokujący reformę)

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -109,10 +109,6 @@ Osoby fizyczne, które przed dniem wejścia w życie niniejszej ustawy, były po
 
 Podstawa wymiaru podatku od nieruchomości, o której mowa w art. 4 ust. 1 pkt 2a lit. a ustawy zmienianej w art. 1 w brzmieniu nadanym niniejszą ustawą, może być zastosowana do wymiaru podatku należnego od roku 2028.
 
-### Art. 8. [ograniczenie wysokości podatku w okresie przejściowym]
-
-W okresie 5 lat od dnia wejścia w życie niniejszej ustawy kwota podatku od nieruchomości należnego od budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego, podlegającego stawce, o której mowa w art. 5a ust. 1 pkt 1 ustawy zmienianej w art. 1, nie może być wyższa niż kwota podatku, jaka byłaby należna od tego przedmiotu opodatkowania przy zastosowaniu stawki podatku od nieruchomości od budynków mieszkalnych określonej w art. 5 ust. 1 pkt 2 lit. a ustawy z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z 2025 r. poz. 707, 726 i 1113).
-
-### Art. 9. [wejście w życie]
+### Art. 8. [wejście w życie]
 
 Ustawa wchodzi w życie z dniem 1 stycznia 2027 r.


### PR DESCRIPTION
## Zmiana

Usunięcie Art. 8 w całości. Dotychczasowy Art. 9 (wejście w życie) staje się Art. 8.

## Co robi obecny Art. 8

Ogranicza podatek od 1. i 2. nieruchomości (ust. 1 pkt 1) tak, aby przez **5 lat** nie przekraczał kwoty wynikającej ze starej stawki powierzchniowej (art. 5 ust. 1 pkt 2 lit. a -- obecnie 1,25 PLN/m²).

Dla mieszkania 65 m² o wartości 600 tys. PLN to limit na poziomie **~81 PLN/rok**.

## Wpływ Art. 8 na obecną ustawę (stawka 0,02%)

| Rok | Stawka ad valorem | Podatek naliczony | Limit z Art. 8 | Podatek faktyczny |
|---|---|---|---|---|
| 2027 | 0,02% | 120 PLN | 81 PLN | **81 PLN** |
| 2028 | 0,02% | 120 PLN | 81 PLN | **81 PLN** |
| 2029 | 0,02% | 120 PLN | 81 PLN | **81 PLN** |
| 2030 | 0,02% | 120 PLN | 81 PLN | **81 PLN** |
| 2031 | 0,02% | 120 PLN | 81 PLN | **81 PLN** |
| 2032+ | 0,02% | 120 PLN | brak | **120 PLN** |

Nawet przy obecnej stawce 0,02% Art. 8 blokuje reformę przez 5 lat.

## Wpływ Art. 8 w połączeniu z PR #6 (stawka 0,1%/0,2%)

| Rok | Stawka (1. nieruchomość) | Podatek naliczony | Limit z Art. 8 | Podatek faktyczny |
|---|---|---|---|---|
| 2027 | 0,1% | 600 PLN | 81 PLN | **81 PLN** |
| 2028 | 0,1% | 600 PLN | 81 PLN | **81 PLN** |
| 2029 | 0,1% | 600 PLN | 81 PLN | **81 PLN** |
| 2030 | 0,1% | 600 PLN | 81 PLN | **81 PLN** |
| 2031 | 0,1% | 600 PLN | 81 PLN | **81 PLN** |
| 2032+ | 0,1% | 600 PLN | brak | **600 PLN** |

Przy podwyższonej stawce problem jest jeszcze poważniejszy -- Art. 8 redukuje podatek **7-krotnie** przez pół dekady, całkowicie neutralizując reformę.

## Dlaczego dodatkowy okres przejściowy jest zbędny

1. **Stawka bazowa jest już niska** -- nawet przy 0,1% to ~50 PLN/miesiąc na typowe mieszkanie. Nie wymaga dodatkowego łagodzenia.
2. **Stawki progresywne mają własny harmonogram** -- art. 5a ust. 1 pkt 2 wprowadza stawkę stopniowo (obecnie +0,1pp/rok). To jest osobny mechanizm przejściowy.
3. **Dwa nakładające się mechanizmy przejściowe** tworzą niepotrzebną złożoność i opóźniają skuteczność ustawy.
4. **Art. 7 już zapewnia bufor** -- podstawa wymiaru od wartości rynkowej (art. 4 ust. 1 pkt 2a lit. a) może być stosowana dopiero od 2028 r., co daje naturalny rok przejściowy.