### PR TITLE
Wyłączenie lokali wynajmowanych na cele mieszkaniowe ze stawki biznesowej 35,53 zł/m²

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -19,10 +19,13 @@ W ustawie z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z
       „2a) dla budynków mieszkalnych jednorodzinnych i lokali mieszkalnych – wartość ustalana jako iloczyn liczby m² ich powierzchni użytkowej oraz:
       a) średniej ceny transakcyjnej m² powierzchni użytkowej lokali mieszkalnych albo domów jednorodzinnych na terenie gminy, w której znajduje się przedmiot opodatkowania, podanej na dzień 30 września roku poprzedzającego rok podatkowy, na który ustalana jest wysokość podatku, w Portalu Danych o Obrocie Mieszkaniami, o którym mowa w rozdziale 8a ustawy z dnia 20 maja 2021 r. o ochronie praw nabywcy lokalu mieszkalnego lub domu jednorodzinnego oraz Deweloperskim Funduszu Gwarancyjnym (Dz. U. z 2024 r. poz. 695, z 2025 r. poz. 758, 1077, 1167 i 1669 oraz z 2026 r. poz. 27) albo w przypadku braku dostępnych danych o których mowa w lit. a
       b) wskaźnika przeliczeniowego kosztu odtworzenia 1 m² powierzchni użytkowej budynków mieszkalnych określonego przez wojewodę na podstawie art. 2 pkt 12 ustawy z dnia 21 czerwca 2001 r. o ochronie praw lokatorów, mieszkaniowym zasobie gminy i o zmianie Kodeksu cywilnego (Dz. U. z 2023 r. poz. 725), obowiązującego na dzień 31 grudnia roku poprzedzającego rok podatkowy, na który ustalana jest wysokość podatku, na terenie gminy, w której jest położony przedmiot opodatkowania.";
-4. na art. 5 w ust. 1 na pkt 2:
-   1. uchyla się lit. a,
-   2. lit. b otrzymuje brzmienie:
-      „b) związanych z prowadzeniem działalności gospodarczej oraz od budynków mieszkalnych jednorodzinnych i lokali mieszkalnych lub ich części zajętych na prowadzenie działalności gospodarczej – 35,53 zł od 1 m² powierzchni użytkowej,";
+4. W art. 5 wprowadza się następujące zmiany:
+   1) w ust. 1 na pkt 2:
+      a) uchyla się lit. a,
+      b) lit. b otrzymuje brzmienie:
+         „b) związanych z prowadzeniem działalności gospodarczej oraz od budynków mieszkalnych jednorodzinnych i lokali mieszkalnych lub ich części zajętych na prowadzenie działalności gospodarczej – 35,53 zł od 1 m² powierzchni użytkowej;”;
+   2) po ust. 3 dodaje się ust. 4 w brzmieniu:
+      „4. Stawka określona w ust. 1 pkt 2 lit. b nie ma zastosowania do budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego wynajmowanego na cele mieszkaniowe. Do takich nieruchomości stosuje się wyłącznie stawki określone w art. 5a.”
 5. po art. 5 dodaje się art. 5a i art. 5b w brzmieniu:
 
    „**Art. 5a.**


### PR DESCRIPTION

Wprowadzamy zmianę w art. 5, która rozwiązuje jedną z kluczowych luk w mechanizmie progresji.

### 1. Jaki problem rozwiązujemy?

Obecnie lokale mieszkalne wynajmowane (zarówno długoterminowo, jak i krótkoterminowo) mogą być kwalifikowane jako „zajęte na prowadzenie działalności gospodarczej”. Dzięki temu ich właściciele płacą tylko płaską stawkę metrażową 35,53 zł/m² zamiast podlegać progresji wartościowej z art. 5a.
W efekcie ustawa anty-spekulacyjna w dużej mierze omija właśnie te nieruchomości, które powinny być jej głównym celem – profesjonalnie wynajmowane mieszkania.

**Główne ryzyka obchodzenia ustawy (które ta zmiana adresuje):**

* Tworzenie spółek celowych – obecnie trywialnie proste: jedna spółka = jedno mieszkanie = stawka biznesowa. Po zmianie takie mieszkania będą wchodzić w progresję wartościową.
* Przejęcie rynku najmu przez duże podmioty gospodarcze – bez tej zmiany profesjonalni wynajmujący (spółki, holdingi, fundacje rodzinne) mogliby masowo unikać progresji, co stopniowo wypychałoby z rynku małych prywatnych właścicieli i pogarszało dostępność mieszkań dla zwykłych ludzi.

### 2. Co zmienia ta poprawka?
Dodajemy prosty zapis, że stawka biznesowa nie ma zastosowania do lokali mieszkalnych wynajmowanych na cele mieszkaniowe. Takie lokale będą podlegały wyłącznie progresji wartościowej z art. 5a.

**Dlaczego ten zapis nie rozwiązuje kwestii Airbnb?**
Wynajem krótkoterminowy (Airbnb, Booking itp.) jest w praktyce traktowany przez organy podatkowe i sądy jako działalność hotelarska/usługowa, a nie „wynajem na cele mieszkaniowe”. Dlatego Airbnb najprawdopodobniej nadal będzie podlegać stawce biznesowej 35,53 zł/m². Te kwestie prawdopodobnie powinny być uregulowane osobno.

**Zalety:**
- Bezpośrednio realizuje cel ustawy – mieszkania przeznaczone na wynajem wchodzą w mechanizm anty-spekulacyjny.
- Proste i czytelne rozwiązanie.
- Nie uderza w małe firmy rodzinne (gabinety, pracownie, krawiectwo itp.), które realnie prowadzą działalność usługową w lokalu.

**Wady:**

- Nie obejmuje wynajmu krótkoterminowego (Airbnb).

### 3. Dlaczego nie inne podejścia?

Ograniczenie stawki biznesowej do „1 lokalu na podmiot” – zbyt skomplikowane i łatwo obchodzone przez spółki celowe.
Szczegółowe rozróżnianie krótkiego i długiego najmu – niepotrzebnie komplikuje ustawę i tworzy pole do sporów interpretacyjnych.
Całkowite usunięcie stawki biznesowej dla wszystkich lokali mieszkalnych – zbyt agresywne wobec małych przedsiębiorców prowadzących działalność w mieszkaniu.

Proponuję najprostsze i najbardziej celowane rozwiązanie, które bezpośrednio wspiera główny cel ustawy bez nadmiernego komplikowania przepisów.