### PR TITLE
Art. 5 (nowy): Anti-Flip Tax - zmiana ustawy o PCC

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -82,13 +82,29 @@ W ustawie z dnia 17 października 2025 r. o zmianie ustawy o ochronie praw nabyw
 
 – z możliwością dokonania przez użytkownika Portalu DOM dyspozycji ich zawężenia do wybranej lokalizacji, charakterystyki nieruchomości lub transakcji oraz okresu nie dłuższego niż dwa lata poprzedzające dokonanie dyspozycji takiego zawężenia.";
 
+### Art. 5. [zmiana ustawy o podatku od czynności cywilnoprawnych]
+
+W ustawie z dnia 9 września 2000 r. o podatku od czynności cywilnoprawnych (Dz. U. z 2024 r. poz. 295) po art. 7 dodaje się art. 7a w brzmieniu:
+
+„**Art. 7a.**
+
+1. Stawka podatku od umowy sprzedaży budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego stanowiącego trzeci albo kolejny budynek mieszkalny jednorodzinny lub lokal mieszkalny zbywany przez podatnika, liczonego zgodnie z art. 5a ust. 2 i 3 ustawy z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych, wynosi:
+   1. 16% - jeżeli zbycie następuje przed upływem 12 miesięcy od dnia nabycia;
+   2. 12% - jeżeli zbycie następuje po upływie 12 miesięcy, ale przed upływem 24 miesięcy od dnia nabycia;
+   3. 8% - jeżeli zbycie następuje po upływie 24 miesięcy, ale przed upływem 36 miesięcy od dnia nabycia.
+2. Przepisu ust. 1 nie stosuje się, jeżeli zbycie następuje:
+   1. na rzecz gminy, Skarbu Państwa, towarzystwa budownictwa społecznego, społecznej inicjatywy mieszkaniowej lub spółdzielni mieszkaniowej;
+   2. w wyniku wykonania orzeczenia sądu wydanego w postępowaniu o podział majątku wspólnego po ustaniu wspólności majątkowej małżeńskiej;
+   3. w wyniku konieczności zmiany miejsca zamieszkania związanej z podjęciem lub zmianą zatrudnienia w odległości co najmniej 50 km od miejsca położenia zbywanej nieruchomości, potwierdzonej umową o pracę lub innym dokumentem;
+   4. w związku z trwałą niezdolnością do pracy podatnika lub członka jego rodziny, potwierdzoną orzeczeniem właściwego organu.".
+
 ## *Przepisy przejściowe i końcowe*
 
-### Art. 5. [obowiązek wskazania nieruchomości]
+### Art. 6. [obowiązek wskazania nieruchomości]
 
 Osoby fizyczne, które przed dniem wejścia w życie niniejszej ustawy, były podatnikami podatku od nieruchomości, którego przedmiotem opodatkowania były więcej niż dwa budynki mieszkalne jednorodzinne lub lokale mieszkalne wskazują, w terminie do 31 stycznia 2027 r., właściwemu organowi podatkowemu budynki mieszkalne jednorodzinne lub lokale mieszkalne, w celu ustalenia nieruchomości podlegających stawce opodatkowania określonej w art. 5a ust. 1 pkt 2 ustawy zmienianej w art. 1.
 
-### Art. 6. [przepisy przejściowe dotyczące deklaracji na 2027 r.]
+### Art. 7. [przepisy przejściowe dotyczące deklaracji na 2027 r.]
 
 1. W 2027 r. podatnicy, o których mowa w art. 6 ust. 9 ustawy zmienianej w art. 1, mogą składać deklaracje na podatek od nieruchomości na rok 2027 w terminie do dnia 31 marca 2027 r., jeżeli spełnią warunki określone w ust. 2.
 2. W celu skorzystania z uprawnienia, o którym mowa w ust. 1, podatnicy są obowiązani:
@@ -105,14 +121,14 @@ Osoby fizyczne, które przed dniem wejścia w życie niniejszej ustawy, były po
    1. niższe niż raty podatku od nieruchomości wynikające ze złożonej deklaracji na podatek od nieruchomości na rok 2027 za miesiące, za które zostały uiszczone, brakująca kwota podatku pozostała do zapłaty podlega, bez wezwania organu podatkowego, wpłacie na rachunek właściwej gminy w terminie do dnia 31 marca 2027 r., przy czym kwota wpłacona w tym terminie nie stanowi zaległości podatkowej w rozumieniu przepisów ustawy z dnia 29 sierpnia 1997 r. – Ordynacja podatkowa (Dz. U. z 2025 r. poz. 111, 497, 621, 622, 769, 820, 1203, 1235, 1414, 1417, 1669, 1804 i 1863);
    2. wyższe niż raty podatku od nieruchomości wynikające ze złożonej deklaracji na podatek od nieruchomości na rok 2026 za miesiące, za które zostały uiszczone, kwota powstałej różnicy nie stanowi nadpłaty w rozumieniu przepisów ustawy z dnia 29 sierpnia 1997 r. – Ordynacja podatkowa, a do jej zaliczenia lub zwrotu przepis art. 76 tej ustawy stosuje się odpowiednio.
 
-### Art. 7. [podstawa wymiaru od 2028 r.]
+### Art. 8. [podstawa wymiaru od 2028 r.]
 
 Podstawa wymiaru podatku od nieruchomości, o której mowa w art. 4 ust. 1 pkt 2a lit. a ustawy zmienianej w art. 1 w brzmieniu nadanym niniejszą ustawą, może być zastosowana do wymiaru podatku należnego od roku 2028.
 
-### Art. 8. [ograniczenie wysokości podatku w okresie przejściowym]
+### Art. 9. [ograniczenie wysokości podatku w okresie przejściowym]
 
 W okresie 5 lat od dnia wejścia w życie niniejszej ustawy kwota podatku od nieruchomości należnego od budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego, podlegającego stawce, o której mowa w art. 5a ust. 1 pkt 1 ustawy zmienianej w art. 1, nie może być wyższa niż kwota podatku, jaka byłaby należna od tego przedmiotu opodatkowania przy zastosowaniu stawki podatku od nieruchomości od budynków mieszkalnych określonej w art. 5 ust. 1 pkt 2 lit. a ustawy z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z 2025 r. poz. 707, 726 i 1113).
 
-### Art. 9. [wejście w życie]
+### Art. 10. [wejście w życie]
 
 Ustawa wchodzi w życie z dniem 1 stycznia 2027 r.


### PR DESCRIPTION
Zmiana ustawy o PCC. Podatek od szybkiej odsprzedazy 3+ mieszkania: 16% przy sprzedazy w ciagu roku, 12% do 2 lat, 8% do 3 lat. Wyjatki: sprzedaz gminie/TBS/SIM, podzial majatku, przeprowadzka do pracy 50+ km, niezdolnosc do pracy. Flipperzy - osoby kupujace mieszkania tylko po to, zeby je szybko odsprzedac z zyskiem - pompuja ceny. Ta poprawka sprawia, ze flip przestaje sie oplacac.