### PR TITLE
Art. 5 (nowy): ograniczenia najmu krotkoterminowego (Airbnb)

### DIFF
--- a/USTAWA.md
+++ b/USTAWA.md
@@ -82,13 +82,30 @@ W ustawie z dnia 17 października 2025 r. o zmianie ustawy o ochronie praw nabyw
 
 – z możliwością dokonania przez użytkownika Portalu DOM dyspozycji ich zawężenia do wybranej lokalizacji, charakterystyki nieruchomości lub transakcji oraz okresu nie dłuższego niż dwa lata poprzedzające dokonanie dyspozycji takiego zawężenia.";
 
+### Art. 5. [zmiana ustawy o usługach hotelarskich oraz usługach pilotów wycieczek i przewodników turystycznych]
+
+W ustawie z dnia 29 sierpnia 1997 r. o usługach hotelarskich oraz usługach pilotów wycieczek i przewodników turystycznych (Dz. U. z 2023 r. poz. 1602) po art. 35a dodaje się art. 35b i art. 35c w brzmieniu:
+
+„**Art. 35b.**
+
+1. Świadczenie usług krótkoterminowego najmu lokalu mieszkalnego znajdującego się w budynku mieszkalnym wielorodzinnym, w którym wyodrębniono co najmniej trzy lokale mieszkalne, wymaga uzyskania zgody wspólnoty mieszkaniowej wyrażonej w formie uchwały.
+2. Przez krótkoterminowy najem, o którym mowa w ust. 1, rozumie się odpłatne udostępnianie lokalu mieszkalnego na okres krótszy niż 30 kolejnych dni.
+3. Wspólnota mieszkaniowa może w uchwale, o której mowa w ust. 1, określić warunki świadczenia usług krótkoterminowego najmu, w tym ograniczyć maksymalną liczbę dni w roku kalendarzowym, w których lokal może być udostępniany w ramach takiego najmu.
+4. Usługodawca świadczący usługi krótkoterminowego najmu jest obowiązany zgłosić ten fakt wójtowi (burmistrzowi, prezydentowi miasta) właściwemu ze względu na miejsce położenia lokalu, w terminie 14 dni od dnia rozpoczęcia świadczenia tych usług.
+
+**Art. 35c.**
+
+1. Kto świadczy usługi krótkoterminowego najmu, o którym mowa w art. 35b, bez wymaganej zgody wspólnoty mieszkaniowej, podlega karze grzywny.
+2. Kto świadczy usługi krótkoterminowego najmu bez dokonania zgłoszenia, o którym mowa w art. 35b ust. 4, podlega karze grzywny.
+3. Orzekanie w sprawach, o których mowa w ust. 1 i 2, następuje w trybie przepisów ustawy z dnia 24 sierpnia 2001 r. - Kodeks postępowania w sprawach o wykroczenia (Dz. U. z 2024 r. poz. 977).".
+
 ## *Przepisy przejściowe i końcowe*
 
-### Art. 5. [obowiązek wskazania nieruchomości]
+### Art. 6. [obowiązek wskazania nieruchomości]
 
 Osoby fizyczne, które przed dniem wejścia w życie niniejszej ustawy, były podatnikami podatku od nieruchomości, którego przedmiotem opodatkowania były więcej niż dwa budynki mieszkalne jednorodzinne lub lokale mieszkalne wskazują, w terminie do 31 stycznia 2027 r., właściwemu organowi podatkowemu budynki mieszkalne jednorodzinne lub lokale mieszkalne, w celu ustalenia nieruchomości podlegających stawce opodatkowania określonej w art. 5a ust. 1 pkt 2 ustawy zmienianej w art. 1.
 
-### Art. 6. [przepisy przejściowe dotyczące deklaracji na 2027 r.]
+### Art. 7. [przepisy przejściowe dotyczące deklaracji na 2027 r.]
 
 1. W 2027 r. podatnicy, o których mowa w art. 6 ust. 9 ustawy zmienianej w art. 1, mogą składać deklaracje na podatek od nieruchomości na rok 2027 w terminie do dnia 31 marca 2027 r., jeżeli spełnią warunki określone w ust. 2.
 2. W celu skorzystania z uprawnienia, o którym mowa w ust. 1, podatnicy są obowiązani:
@@ -105,14 +122,14 @@ Osoby fizyczne, które przed dniem wejścia w życie niniejszej ustawy, były po
    1. niższe niż raty podatku od nieruchomości wynikające ze złożonej deklaracji na podatek od nieruchomości na rok 2027 za miesiące, za które zostały uiszczone, brakująca kwota podatku pozostała do zapłaty podlega, bez wezwania organu podatkowego, wpłacie na rachunek właściwej gminy w terminie do dnia 31 marca 2027 r., przy czym kwota wpłacona w tym terminie nie stanowi zaległości podatkowej w rozumieniu przepisów ustawy z dnia 29 sierpnia 1997 r. – Ordynacja podatkowa (Dz. U. z 2025 r. poz. 111, 497, 621, 622, 769, 820, 1203, 1235, 1414, 1417, 1669, 1804 i 1863);
    2. wyższe niż raty podatku od nieruchomości wynikające ze złożonej deklaracji na podatek od nieruchomości na rok 2026 za miesiące, za które zostały uiszczone, kwota powstałej różnicy nie stanowi nadpłaty w rozumieniu przepisów ustawy z dnia 29 sierpnia 1997 r. – Ordynacja podatkowa, a do jej zaliczenia lub zwrotu przepis art. 76 tej ustawy stosuje się odpowiednio.
 
-### Art. 7. [podstawa wymiaru od 2028 r.]
+### Art. 8. [podstawa wymiaru od 2028 r.]
 
 Podstawa wymiaru podatku od nieruchomości, o której mowa w art. 4 ust. 1 pkt 2a lit. a ustawy zmienianej w art. 1 w brzmieniu nadanym niniejszą ustawą, może być zastosowana do wymiaru podatku należnego od roku 2028.
 
-### Art. 8. [ograniczenie wysokości podatku w okresie przejściowym]
+### Art. 9. [ograniczenie wysokości podatku w okresie przejściowym]
 
 W okresie 5 lat od dnia wejścia w życie niniejszej ustawy kwota podatku od nieruchomości należnego od budynku mieszkalnego jednorodzinnego lub lokalu mieszkalnego, podlegającego stawce, o której mowa w art. 5a ust. 1 pkt 1 ustawy zmienianej w art. 1, nie może być wyższa niż kwota podatku, jaka byłaby należna od tego przedmiotu opodatkowania przy zastosowaniu stawki podatku od nieruchomości od budynków mieszkalnych określonej w art. 5 ust. 1 pkt 2 lit. a ustawy z dnia 12 stycznia 1991 r. o podatkach i opłatach lokalnych (Dz. U. z 2025 r. poz. 707, 726 i 1113).
 
-### Art. 9. [wejście w życie]
+### Art. 10. [wejście w życie]
 
 Ustawa wchodzi w życie z dniem 1 stycznia 2027 r.


### PR DESCRIPTION
Wynajem krotkoterminowy (<30 dni) w bloku wymaga zgody wspolnoty mieszkaniowej. Wspolnota moze ograniczyc liczbe dni w roku. Obowiazek zgloszenia do gminy. Grzywna za brak zgody lub zgloszenia. Sasiedzi maja prawo decydowac, czy ich blok zamienia sie w hotel.